### PR TITLE
fix: added extra security measure  for ERC20/ERC721 contracts

### DIFF
--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -5,68 +5,82 @@ import "./IERC20.sol";
 
 contract ERC20 is IERC20 {
     event Transfer(address indexed from, address indexed to, uint256 value);
-    event Approval(
-        address indexed owner, address indexed spender, uint256 value
-    );
+    event Approval(address indexed owner, address indexed spender, uint256 value);
 
     uint256 public totalSupply;
     mapping(address => uint256) public balanceOf;
     mapping(address => mapping(address => uint256)) public allowance;
     string public name;
     string public symbol;
+    uint8 public decimals;
+
+    address private _owner;
+
+    modifier onlyOwner() {
+        require(msg.sender == _owner, "caller is not the owner");
+        _;
+    }
 
     constructor(string memory _name, string memory _symbol, uint8 _decimals) {
         name = _name;
         symbol = _symbol;
         decimals = _decimals;
+        _owner = msg.sender;
     }
 
-    function transfer(address recipient, uint256 amount)
-        external
-        returns (bool)
-    {
+    function transfer(address recipient, uint256 amount) external returns (bool) {
+        require(recipient != address(0), "transfer to zero address");
+        require(balanceOf[msg.sender] >= amount, "transfer amount exceeds balance");
+        require(balanceOf[msg.sender] > 0, "transfer amount must be greater than 0");
+
         balanceOf[msg.sender] -= amount;
         balanceOf[recipient] += amount;
         emit Transfer(msg.sender, recipient, amount);
-
         return true;
     }
 
     function approve(address spender, uint256 amount) external returns (bool) {
+        require(spender != address(0), "approve to 0 address");
+
         allowance[msg.sender][spender] = amount;
         emit Approval(msg.sender, spender, amount);
         return true;
     }
 
-    function transferFrom(address sender, address recipient, uint256 amount)
-        external
-        returns (bool)
-    {
-        require(msg.sender != recipient, "cannot transfer to self");
-        allowance[sender][msg.sender] -= amount;
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool) {
+        require(sender != address(0), "transfer to correct address");
+        require(recipient != address(0), "transfer to correct address");
+        require(balanceOf[sender] >= amount, "transfer amount exceeds balance");
+
         balanceOf[sender] -= amount;
         balanceOf[recipient] += amount;
+        allowance[sender][msg.sender] -= amount;
         emit Transfer(sender, recipient, amount);
         return true;
     }
 
     function _mint(address to, uint256 amount) internal {
+        require(to != address(0), "mint to zero address");
+
         balanceOf[to] += amount;
         totalSupply += amount;
         emit Transfer(address(0), to, amount);
     }
 
     function _burn(address from, uint256 amount) internal {
+        require(from != address(0), "burn from the zero address");
+        require(balanceOf[from] >= amount, "ERC20: burn amount exceeds balance");
+
         balanceOf[from] -= amount;
         totalSupply -= amount;
         emit Transfer(from, address(0), amount);
     }
 
-    function mint(address to, uint256 amount) external {
+    function mint(address to, uint256 amount) external onlyOwner {
         _mint(to, amount);
     }
 
-    function burn(address from, uint256 amount) external {
+    function burn(address from, uint256 amount) external onlyOwner {
         _burn(from, amount);
     }
 }


### PR DESCRIPTION
Description:
This pull request addresses security vulnerabilities and adds security measures to both the ERC20 and ERC721 contracts. Below is a summary of the changes i made:

Changes made:
ERC20 Contract:
Added: onlyOwner modifier to restrict minting and burning functions to the contract owner.
Refactored: The transferFrom function to ensure balance checks and proper authorization.

ERC721 Contract:
Added: require check to certain functions to enhance security.
Refactored: ensuring only the owner can mint new tokens.