### PR TITLE
refac: Improve ERC20/ERC721 token contracts against vulnerabilities/loopholes 

### DIFF
--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -8,12 +8,14 @@ contract ERC20 is IERC20 {
     event Approval(
         address indexed owner, address indexed spender, uint256 value
     );
-
+    
+    address internal owner;
     uint256 public totalSupply;
     mapping(address => uint256) public balanceOf;
     mapping(address => mapping(address => uint256)) public allowance;
     string public name;
     string public symbol;
+    uint8 public decimals;
 
     constructor(string memory _name, string memory _symbol, uint8 _decimals) {
         name = _name;
@@ -21,18 +23,26 @@ contract ERC20 is IERC20 {
         decimals = _decimals;
     }
 
+    modifier onlyOwner {
+    require(owner == msg.sender, "Caller not owner");
+    _;
+    }
+
+
     function transfer(address recipient, uint256 amount)
         external
         returns (bool)
     {
+        require(recipient != address(0), "Invalid address");
+        require(balanceOf[msg.sender] > 0, "insufficient funds");
         balanceOf[msg.sender] -= amount;
         balanceOf[recipient] += amount;
         emit Transfer(msg.sender, recipient, amount);
-
         return true;
     }
 
     function approve(address spender, uint256 amount) external returns (bool) {
+    require(spender != address(0), "Invalid address");
         allowance[msg.sender][spender] = amount;
         emit Approval(msg.sender, spender, amount);
         return true;
@@ -42,7 +52,8 @@ contract ERC20 is IERC20 {
         external
         returns (bool)
     {
-        require(msg.sender != recipient, "cannot transfer to self");
+        require(msg.sender != recipient, "can not transfer");
+        require(balanceOf[sender] > 0, "No enough funds");
         allowance[sender][msg.sender] -= amount;
         balanceOf[sender] -= amount;
         balanceOf[recipient] += amount;
@@ -51,6 +62,8 @@ contract ERC20 is IERC20 {
     }
 
     function _mint(address to, uint256 amount) internal {
+        require(to == owner);
+
         balanceOf[to] += amount;
         totalSupply += amount;
         emit Transfer(address(0), to, amount);
@@ -62,11 +75,11 @@ contract ERC20 is IERC20 {
         emit Transfer(from, address(0), amount);
     }
 
-    function mint(address to, uint256 amount) external {
+    function mint(address to, uint256 amount) external onlyOwner {
         _mint(to, amount);
     }
 
-    function burn(address from, uint256 amount) external {
+    function burn(address from, uint256 amount) external onlyOwner{
         _burn(from, amount);
     }
 }

--- a/contracts/ERC721.sol
+++ b/contracts/ERC721.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+
+
+// interface for IERC165
 interface IERC165 {
     function supportsInterface(bytes4 interfaceID)
         external
@@ -8,6 +11,7 @@ interface IERC165 {
         returns (bool);
 }
 
+// interface for IERC721 inheriting IERC165
 interface IERC721 is IERC165 {
     function balanceOf(address owner) external view returns (uint256 balance);
     function ownerOf(uint256 tokenId) external view returns (address owner);
@@ -32,6 +36,8 @@ interface IERC721 is IERC165 {
         returns (bool);
 }
 
+
+// interface for IERC721's Receiver
 interface IERC721Receiver {
     function onERC721Received(
         address operator,
@@ -41,13 +47,20 @@ interface IERC721Receiver {
     ) external returns (bytes4);
 }
 
-contract ERC721 is IERC721 {
+contract ERC721 is IERC721{
+
+
+//declaring the transfer event
     event Transfer(
         address indexed from, address indexed to, uint256 indexed id
     );
+
+    //declaring the approval event
     event Approval(
         address indexed owner, address indexed spender, uint256 indexed id
     );
+
+    //declaring the approvalforall event
     event ApprovalForAll(
         address indexed owner, address indexed operator, bool approved
     );
@@ -64,6 +77,7 @@ contract ERC721 is IERC721 {
     // Mapping from owner to operator approvals
     mapping(address => mapping(address => bool)) public isApprovedForAll;
 
+
     function supportsInterface(bytes4 interfaceId)
         external
         pure
@@ -72,6 +86,7 @@ contract ERC721 is IERC721 {
         return interfaceId == type(IERC721).interfaceId
             || interfaceId == type(IERC165).interfaceId;
     }
+
 
     function ownerOf(uint256 id) external view returns (address owner) {
         owner = _ownerOf[id];
@@ -90,6 +105,7 @@ contract ERC721 is IERC721 {
 
     function approve(address spender, uint256 id) external {
         address owner = _ownerOf[id];
+        require(spender != address(0), "invalid spender address");
         require(
             msg.sender == owner || isApprovedForAll[owner][msg.sender],
             "not authorized"
@@ -134,6 +150,7 @@ contract ERC721 is IERC721 {
     function safeTransferFrom(address from, address to, uint256 id) external {
         transferFrom(from, to, id);
 
+      require(_isApprovedOrOwner(msg.sender,from, id), "Caller is not owner nor approved");
         require(
             to.code.length == 0
                 || IERC721Receiver(to).onERC721Received(msg.sender, from, id, "")
@@ -150,7 +167,9 @@ contract ERC721 is IERC721 {
     ) external {
         transferFrom(from, to, id);
 
-        require(
+     require(_isApprovedOrOwner(msg.sender,from, id), "Caller is not owner nor approved");
+     require(to != address(0), "Cannot transfer to zero address");
+     require(
             to.code.length == 0
                 || IERC721Receiver(to).onERC721Received(msg.sender, from, id, data)
                     == IERC721Receiver.onERC721Received.selector,
@@ -183,11 +202,12 @@ contract ERC721 is IERC721 {
 
 contract MyNFT is ERC721 {
     function mint(address to, uint256 id) external {
+require(msg.sender == _ownerOf[id], "Can't call this function");
         _mint(to, id);
     }
 
-    function burn(uint256 id) external {
-        require(msg.sender == _ownerOf[id], "not owner");
+    function burn(uint256 id) external  {
+        require(msg.sender == _ownerOf[id], "Can't call this function");
         _burn(id);
     }
 }


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to BlockHeaderWeb3! -->


 **ERC20 token contract**

-   Added  **onlyOwner** modifier to check that **owner** == **msg.sender** where necessary in the contract.

-  Included **onlyOwner** modifier check in **mint** and **burn** functions restrict random addressess from calling the functions.

-  Added necessary checks to other functions.

**ERC721 token contract**

-  Added restriction checks  to functions  where necessary to restrict access to certain functions in the contract that could make it vulnerable to malicious users. 




